### PR TITLE
feat: allow setting custom guzzle options

### DIFF
--- a/config/unicon.php
+++ b/config/unicon.php
@@ -68,6 +68,7 @@ return [
     'iconify' => [
         'url' => 'https://api.iconify.design',
         'timeout' => 5,
+        'verify' => true,
     ],
 
 ];

--- a/config/unicon.php
+++ b/config/unicon.php
@@ -67,8 +67,9 @@ return [
 
     'iconify' => [
         'url' => 'https://api.iconify.design',
-        'timeout' => 5,
-        'verify' => true,
+        'request_options' => [
+            'timeout' => 5,
+        ],
     ],
 
 ];

--- a/docs/config-reference.mdx
+++ b/docs/config-reference.mdx
@@ -46,15 +46,20 @@ icon: 'gear'
 
            If the request times out, the component won't be rendered.
        </ParamField>
-       <ParamField path="verify" type="boolean|string" default="true">
-           This value controls whether the SSL certificate should be verifiedm when making requests
-           to the Iconify API.
+       <ParamField path="request_options" type="map" default="['timeout' => 5]">
+            This value is a map of http request options to be passed to the underlying Guzzle client
+            for all requests to the Iconify API.
 
-            - Set to `true` to enable the certificate verification.
-            - Set to `false` to disable the certificate verification.
+            For example, you can set the `timeout` option to set a custom timeout.
 
-           For more information, see the Guzzle documentation about the 
-           [verify](https://docs.guzzlephp.org/en/stable/request-options.html#verify) option.
+            ```php
+            'request_options' => [
+                'timeout' => 10,
+            ],
+            ```
+
+            See the Guzzle documentation about the [request options](https://docs.guzzlephp.org/en/stable/request-options.html)
+            for more information.
        </ParamField>
    </Expandable>
 </ParamField>

--- a/docs/config-reference.mdx
+++ b/docs/config-reference.mdx
@@ -47,11 +47,14 @@ icon: 'gear'
            If the request times out, the component won't be rendered.
        </ParamField>
        <ParamField path="verify" type="boolean|string" default="true">
-           This value sets if the SSL certificate is getting verified. 
+           This value controls whether the SSL certificate should be verifiedm when making requests
+           to the Iconify API.
 
-            - Set `true` to enable SSL certificate verification and use the default CA bundle provided by operating system.
-            - Set `false` to disable certificate verification (this is insecure!).
-            - Set to a string to provide the path to a CA bundle to enable verification using a custom certificate.
+            - Set to `true` to enable the certificate verification.
+            - Set to `false` to disable the certificate verification.
+
+           For more information, see the Guzzle documentation about the 
+           [verify](https://docs.guzzlephp.org/en/stable/request-options.html#verify) option.
        </ParamField>
    </Expandable>
 </ParamField>

--- a/docs/config-reference.mdx
+++ b/docs/config-reference.mdx
@@ -46,5 +46,12 @@ icon: 'gear'
 
            If the request times out, the component won't be rendered.
        </ParamField>
+       <ParamField path="verify" type="boolean|string" default="true">
+           This value sets if the SSL certificate is getting verified. 
+
+            - Set `true` to enable SSL certificate verification and use the default CA bundle provided by operating system.
+            - Set `false` to disable certificate verification (this is insecure!).
+            - Set to a string to provide the path to a CA bundle to enable verification using a custom certificate.
+       </ParamField>
    </Expandable>
 </ParamField>

--- a/src/IconDownloader.php
+++ b/src/IconDownloader.php
@@ -27,6 +27,7 @@ class IconDownloader
         try {
             return Http::baseUrl(config('unicon.iconify.url'))
                 ->timeout(config('unicon.iconify.timeout', 5))
+                ->withOptions(['verify' => config('unicon.iconify.verify', true)])
                 ->get("$prefix/$name.svg")
                 ->throwUnlessStatus(200)
                 ->body();

--- a/src/IconDownloader.php
+++ b/src/IconDownloader.php
@@ -26,8 +26,7 @@ class IconDownloader
     {
         try {
             return Http::baseUrl(config('unicon.iconify.url'))
-                ->timeout(config('unicon.iconify.timeout', 5))
-                ->withOptions(['verify' => config('unicon.iconify.verify', true)])
+                ->withOptions(config('unicon.iconify.request_options', []))
                 ->get("$prefix/$name.svg")
                 ->throwUnlessStatus(200)
                 ->body();


### PR DESCRIPTION
In some cases, especially on local hosts, there might be a problem with SSL verification.

This PR fixes this by adding a possibility to turn off the verification via config.
