### PR TITLE
feat: add support for default prefix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1f4e6821e6bd222eaa295d5c99c1994",
+    "content-hash": "70a4c64dc5c24a06935b7b165f5459a3",
     "packages": [
         {
             "name": "brick/math",

--- a/src/IconRenderer.php
+++ b/src/IconRenderer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Unicon;
 
-use Illuminate\Support\Str;
-
 class IconRenderer
 {
     public function __construct(
@@ -15,13 +13,16 @@ class IconRenderer
 
     public function render(string $name): ?string
     {
-        if (! Str::contains($name, ':')) {
+        $parts = explode(':', $name, 2);
+
+        $prefix = count($parts) === 2 ? $parts[0] : config('unicon.defaults.prefix');
+        $name = count($parts) === 2 ? $parts[1] : $name;
+
+        if (!$prefix) {
             throw new \InvalidArgumentException(
-                'The name must be in the format "prefix:name".',
+                'The prefix must be specified either in the name of the icon or in the configuration.',
             );
         }
-
-        [$prefix, $name] = explode(':', $name, 2);
 
         $icon = match ($isInCache = $this->cache->has($prefix, $name)) {
             true => $this->cache->pull($prefix, $name),

--- a/test/Feature/IconRendererTest.php
+++ b/test/Feature/IconRendererTest.php
@@ -46,4 +46,19 @@ class IconRendererTest extends TestCase
         $renderer->render('heroicons:clock'); // downloads the icon
         $renderer->render('heroicons:clock'); // pulls the icon from the cache
     }
+
+    #[Test]
+    public function test_it_uses_the_defaullt_prefix_if_the_prefix_is_not_specified()
+    {
+        $this->partialMock(IconDownloader::class)
+            ->shouldReceive('download')
+            ->once()
+            ->with('heroicons', 'clock')
+            ->andReturn($this->icon);
+
+        Config::set('unicon.defaults.prefix', 'heroicons');
+
+        $renderer = $this->app->make(IconRenderer::class);
+        $renderer->render('clock');
+    }
 }

--- a/test/Feature/IconRendererTest.php
+++ b/test/Feature/IconRendererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Unicon\Test\Feature;
 
+use Illuminate\Support\Facades\Config;
 use Unicon\IconCache;
 use Unicon\IconDownloader;
 use Unicon\IconRenderer;


### PR DESCRIPTION
This PR introduces a new configuration option that allows setting a default prefix.

This is useful when you choose one icon set as your main icon set and want to avoid prefixing all icon names manually.

For example, setting `unicon.defaults.prefix` to `heroicons` allows you to render icons with the following syntax.

```diff
+ <x-icon name="clock" />
- <x-icon name="heroicons:clock" />
```

Closes #1 